### PR TITLE
Fix duplicate .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ pip-wheel-metadata/
 
 # Python egg metadata
 *.egg-info/
-dist/
-build/
 
 # Node modules
 node_modules/


### PR DESCRIPTION
## Summary
- clean up `.gitignore` by removing duplicate `dist/` and `build/` entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e81bba4108329bbb7eff5aa2ef511