### PR TITLE
UI fixes for markdown and theme

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request, jsonify
+import markdown
 import json
 import os
 import time
@@ -105,8 +106,9 @@ def index():
 def problem_page(name):
     if name not in list_problems():
         return 'Problem not found', 404
-    description = load_description(name)
-    return render_template('problem.html', problem=name, description=description)
+    description_md = load_description(name)
+    description_html = markdown.markdown(description_md)
+    return render_template('problem.html', problem=name, description=description_html)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask>=3.0.0
+Markdown>=3.8.2

--- a/templates/problem.html
+++ b/templates/problem.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/codemirror.min.css">
     <link rel="stylesheet" id="theme-link" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/theme/eclipse.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.2.0/github-markdown.min.css">
     <style>
       body { padding: 2rem; }
       #output { white-space: pre-wrap; }
@@ -16,7 +17,7 @@
 <div class="container">
     <a href="/">&lt; Back</a>
     <h1 class="mt-2 mb-3">{{ problem }}</h1>
-    <pre id="description" class="p-3 border bg-light">{{ description }}</pre>
+    <div id="description" class="markdown-body p-3 border bg-light">{{ description|safe }}</div>
     <div class="row mt-3">
         <div class="col-md-6">
             <label for="language-select" class="form-label">Language</label>
@@ -31,11 +32,13 @@
             <label for="theme-select" class="form-label">Editor Theme</label>
             <select id="theme-select" class="form-select mb-2">
                 <option value="eclipse" selected>Light</option>
-                <option value="solarized dark">Solarized Dark</option>
+                <option value="monokai">Monokai</option>
             </select>
         </div>
     </div>
-    <textarea id="code">def solve():\n    pass</textarea>
+    <textarea id="code">def solve():
+    pass
+</textarea>
     <div class="mt-2">
         <button id="run" class="btn btn-primary">Test</button>
         <button id="submit" class="btn btn-success ms-2">Submit</button>


### PR DESCRIPTION
## Summary
- render problem descriptions using Markdown
- update default code snippet with actual newline
- include GitHub markdown styles
- add Monokai as dark theme option
- note Markdown dependency

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6875ab4af7488329a2299591c6d74feb